### PR TITLE
fix: remove deprecated @list.of usage

### DIFF
--- a/src/lib/gif_decoder.mbt
+++ b/src/lib/gif_decoder.mbt
@@ -305,7 +305,11 @@ pub fn create_gif_data_blocks() -> @list.List[GifDataBlock] {
     application_auth_code: "2.0",
     application_data: @list.List::from_array([b'1', b'0']),
   }
-  @list.List::from_array([Extension(Application(app_ext)), Image(image_data), Trailer])
+  @list.List::from_array([
+    Extension(Application(app_ext)),
+    Image(image_data),
+    Trailer,
+  ])
 }
 
 ///|

--- a/src/lib/pkg.generated.mbti
+++ b/src/lib/pkg.generated.mbti
@@ -1,0 +1,604 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "Penguinsltp/gif_decoder/src/lib"
+
+import(
+  "moonbitlang/core/list"
+)
+
+// Values
+pub fn analyze_gif_structure(Bytes) -> Result[String, String]
+
+pub let application_extension_label : Byte
+
+pub fn apply_color_table(@list.List[Byte], @list.List[ColorTableEntry], Int?) -> @list.List[RgbaColor]
+
+pub fn apply_color_table_with_options(@list.List[Byte], @list.List[ColorTableEntry], Int?, TransparencyOptions) -> @list.List[RgbaColor]
+
+pub fn apply_disposal_method_to_canvas(Canvas, Canvas?, DisposalMethod, Int, Int, Int, Int) -> Canvas
+
+pub fn apply_graphic_control(Canvas, GraphicControlExtension, @list.List[Byte], @list.List[ColorTableEntry], ImageDescriptor) -> Result[Canvas, GifError]
+
+pub fn array_bytes_to_list(Array[Byte]) -> @list.List[Byte]
+
+pub fn bytes_to_string(Bytes, Int, Int) -> String
+
+pub fn calculate_color_table_size(Int) -> Int
+
+pub fn color_entry_to_rgba(ColorTableEntry, Int) -> RgbaColor
+
+pub let comment_label : Byte
+
+pub fn create_color_entry(Int, Int, Int) -> ColorTableEntry
+
+pub fn create_color_table_entry(Int, Int, Int) -> ColorTableEntry
+
+pub fn create_default_image_descriptor(Int, Int) -> ImageDescriptor
+
+pub fn create_default_logical_screen(Int, Int) -> LogicalScreenDescriptor
+
+pub fn create_disposal_method(Int) -> DisposalMethod
+
+pub fn create_frame(ImageData, @list.List[ColorTableEntry]?, GraphicControlExtension?, Int, Int) -> Result[ImageFrame, GifError]
+
+pub fn create_frame_from_rgba(Int, Int, Int, Int, Array[RgbaColor], Int, Int) -> Result[GifFrameInput, GifError]
+
+pub fn create_frame_with_options(ImageData, @list.List[ColorTableEntry]?, GraphicControlExtension?, Int, Int, TransparencyOptions) -> Result[ImageFrame, GifError]
+
+pub fn create_gif_data_blocks() -> @list.List[GifDataBlock]
+
+pub fn create_gif_encoder_options(Int, Int, @list.List[ColorTableEntry]?, Int, Int, Int) -> GifEncoderOptions
+
+pub fn create_gif_header(String) -> GifHeader
+
+pub fn create_image_data(ImageDesc, @list.List[Byte]) -> ImageData
+
+pub fn create_parse_options(Bool, Bool, Int?) -> GifParseOptions
+
+pub fn create_rgba_color(Int, Int, Int, Int) -> RgbaColor
+
+pub fn create_test_gif_data() -> Bytes
+
+pub fn create_transparency_options(TransparencyStrategy, Int, Bool, RgbaColor) -> TransparencyOptions
+
+pub fn decode_gif_basic(Bytes) -> Result[String, String]
+
+pub fn decode_gif_complete(Bytes) -> Result[String, String]
+
+pub fn decode_lzw(@list.List[Byte], Int) -> Result[@list.List[Byte], GifError]
+
+pub fn decode_lzw_from_array(Array[Int], Int) -> Result[Array[Int], GifError]
+
+pub fn default_optimization_options() -> GifOptimizationOptions
+
+pub fn default_parse_options() -> GifParseOptions
+
+pub fn default_streaming_options() -> StreamingDecoderOptions
+
+pub fn default_transparency_options() -> TransparencyOptions
+
+pub let disposal_keep : Int
+
+pub let disposal_none : Int
+
+pub let disposal_restore_background : Int
+
+pub let disposal_restore_previous : Int
+
+pub let extension_introducer : Byte
+
+pub fn extract_animation_info(Gif) -> AnimationInfo
+
+pub fn fast_clear_region(Canvas, Int, Int, Int, Int, RgbaColor) -> Unit
+
+pub fn find_image_descriptor(Bytes, Int) -> Result[Int, String]
+
+pub fn get_color_table_size_from_descriptor(LogicalScreenDescriptor) -> Int
+
+pub fn get_effective_color_table(ImageData, @list.List[ColorTableEntry]?) -> @list.List[ColorTableEntry]?
+
+pub fn get_local_color_table_size(ImageDescriptor) -> Int
+
+pub let gif_signature : String
+
+pub let gif_version_87a : String
+
+pub let gif_version_89a : String
+
+pub let graphic_control_label : Byte
+
+pub fn has_global_color_table(LogicalScreenDescriptor) -> Bool
+
+pub fn has_local_color_table(ImageDescriptor) -> Bool
+
+pub let image_separator : Byte
+
+pub fn is_valid_disposal_method(Int) -> Bool
+
+pub let lzw_clear_code : Int
+
+pub let lzw_end_code : Int
+
+pub let lzw_first_code : Int
+
+pub let lzw_max_code_size : Int
+
+pub fn merge_color_tables(@list.List[ColorTableEntry]?, @list.List[ColorTableEntry]?, Int) -> @list.List[ColorTableEntry]
+
+pub fn new(@list.List[Byte]) -> BitReader
+
+pub fn normalize_pixel_data(@list.List[Byte], Int, Bool) -> Result[@list.List[Byte], GifError]
+
+pub fn optimize_gif(Gif, GifOptimizationOptions) -> (Gif, OptimizationReport)
+
+pub fn pack_image_packed_field(Bool, Bool, Bool, Int) -> Int
+
+pub fn pack_logical_screen_packed_field(Bool, Int, Bool, Int) -> Int
+
+pub fn parse_application_extension_block(Bytes, Int, Bool) -> Result[(ApplicationExtension, Int), GifError]
+
+pub fn parse_color_table_from_bytes(Bytes, Int, Int) -> Result[(@list.List[ColorTableEntry], Int), GifError]
+
+pub fn parse_extension_info(Bytes, Int) -> Result[(String, Int), String]
+
+pub fn parse_gif(Bytes) -> Result[Gif, GifError]
+
+pub fn parse_gif_header(Bytes) -> Result[GifHeader, GifError]
+
+pub fn parse_gif_info(Bytes) -> Result[GifInfo, String]
+
+pub fn parse_gif_with_options(Bytes, GifParseOptions) -> Result[Gif, GifError]
+
+pub fn parse_global_color_table(Bytes, Int, Int) -> Result[Array[ColorEntry], String]
+
+pub fn parse_graphic_control_block(Bytes, Int) -> Result[(GraphicControlExtension, Int), GifError]
+
+pub fn parse_image_descriptor(Bytes, Int) -> Result[(ImageDesc, Int), String]
+
+pub fn parse_image_descriptor_block(Bytes, Int) -> Result[(ImageDescriptor, Int), GifError]
+
+pub fn parse_logical_screen_descriptor_block(Bytes) -> Result[(LogicalScreenDescriptor, Int), GifError]
+
+pub fn parse_plain_text_block(Bytes, Int, Bool) -> Result[(PlainTextExtension, Int), GifError]
+
+pub let plain_text_label : Byte
+
+pub fn rebuild_gif(Gif, @list.List[GifDataBlock]) -> Gif
+
+pub fn render_all_frames(Gif) -> Result[@list.List[ImageFrame], GifError]
+
+pub fn render_all_frames_with_options(Gif, TransparencyOptions) -> Result[@list.List[ImageFrame], GifError]
+
+pub fn render_frame_to_canvas(Canvas, ImageData, @list.List[ColorTableEntry], Int?) -> Result[Unit, GifError]
+
+pub fn render_frame_to_canvas_with_options(Canvas, ImageData, @list.List[ColorTableEntry], Int?, TransparencyOptions) -> Result[Unit, GifError]
+
+pub fn render_pixels_to_canvas(Canvas, @list.List[RgbaColor], ImageDescriptor) -> Result[Canvas, GifError]
+
+pub fn test_all_type_constructions() -> Result[String, GifError]
+
+pub fn to_int8(Byte) -> Int
+
+pub fn to_u16_le(Byte, Byte) -> Int
+
+pub let trailer : Byte
+
+pub fn transparency_strategy_alpha_threshold() -> TransparencyStrategy
+
+pub fn transparency_strategy_binary() -> TransparencyStrategy
+
+pub fn transparency_strategy_preserve_alpha() -> TransparencyStrategy
+
+pub fn unpack_image_packed_field(Int) -> (Bool, Bool, Bool, Int)
+
+pub fn unpack_logical_screen_packed_field(Int) -> (Bool, Int, Bool, Int)
+
+pub fn validate_dimensions(Int, Int) -> Result[Unit, GifError]
+
+pub fn validate_gif_header(GifHeader) -> Result[Unit, GifError]
+
+pub fn validate_graphic_control(GraphicControlExtension) -> Result[Unit, GifError]
+
+pub fn validate_image_descriptor(ImageDescriptor) -> Result[Unit, GifError]
+
+pub fn validate_logical_screen(LogicalScreenDescriptor) -> Result[Unit, GifError]
+
+pub fn wasm_decode_gif_summary(Bytes) -> Result[String, String]
+
+pub fn wasm_encode_single_frame(Array[RgbaColor], Int, Int) -> Result[Bytes, String]
+
+pub fn wasm_optimize_gif(Bytes) -> Result[String, String]
+
+pub fn wasm_stream_decode(Bytes, Int) -> Result[Int, String]
+
+// Errors
+
+// Types and methods
+pub struct AnimationController {
+  frames : @list.List[ImageFrame]
+  image_descriptors : @list.List[ImageDescriptor]
+  state : AnimationState
+}
+pub fn AnimationController::current_frame(Self) -> ImageFrame?
+pub fn AnimationController::get_current_pixels(Self) -> Array[RgbaColor]?
+pub fn AnimationController::is_finished(Self) -> Bool
+pub fn AnimationController::new(@list.List[ImageFrame], @list.List[ImageDescriptor], Int, Int, Int) -> Self
+pub fn AnimationController::reset(Self) -> Unit
+pub fn AnimationController::update(Self, Int) -> Bool
+pub impl Show for AnimationController
+
+pub struct AnimationInfo {
+  loop_count : Int
+  background_color_index : Int
+  pixel_aspect_ratio : Int
+}
+pub impl Show for AnimationInfo
+
+pub struct AnimationState {
+  mut current_frame : Int
+  mut accumulated_time : Int
+  total_frames : Int
+  mut played_loops : Int
+  loop_count : Int
+  renderer : CanvasRenderer?
+}
+pub impl Show for AnimationState
+
+pub struct ApplicationExtension {
+  application_identifier : String
+  application_auth_code : String
+  application_data : @list.List[Byte]
+}
+pub impl Show for ApplicationExtension
+
+pub struct BitReader {
+  data : @list.List[Byte]
+  current_byte : Byte
+  bit_offset : Int
+  bits_consumed : Int
+  initialized : Bool
+}
+pub fn BitReader::read_bits(Self, Int) -> (Self, Int?)
+
+pub struct Canvas {
+  width : Int
+  height : Int
+  pixels : Array[RgbaColor]
+  background_color : RgbaColor
+  mut previous_frame : Array[RgbaColor]?
+}
+pub fn Canvas::apply_disposal_method(Self, Int, Int, Int, Int, Int) -> Unit
+pub fn Canvas::clear_to_background(Self) -> Unit
+pub fn Canvas::new(Int, Int, RgbaColor) -> Self
+pub fn Canvas::save_previous_frame(Self) -> Unit
+pub impl Show for Canvas
+
+pub struct CanvasRenderer {
+  canvas : Canvas
+  mut previous_disposal : Int
+  mut previous_bounds : (Int, Int, Int, Int)
+}
+pub fn CanvasRenderer::get_canvas_pixels(Self) -> Array[RgbaColor]
+pub fn CanvasRenderer::new(Int, Int, RgbaColor) -> Self
+pub fn CanvasRenderer::render_frame_with_disposal(Self, ImageFrame, ImageDescriptor) -> Result[Unit, GifError]
+pub impl Show for CanvasRenderer
+
+pub struct CodeReader {
+  data : @list.List[Byte]
+  mut bit_buffer : Int
+  mut bit_count : Int
+  mut byte_index : Int
+}
+pub fn CodeReader::new(@list.List[Byte]) -> Self
+pub fn CodeReader::read_code(Self, Int) -> Int?
+
+pub struct ColorEntry {
+  red : Int
+  green : Int
+  blue : Int
+}
+pub impl Eq for ColorEntry
+pub impl Show for ColorEntry
+
+pub struct ColorTableEntry {
+  red : Int
+  green : Int
+  blue : Int
+}
+pub impl Eq for ColorTableEntry
+pub impl Show for ColorTableEntry
+
+pub struct CommentExtension {
+  comment_data : @list.List[Byte]
+}
+pub impl Show for CommentExtension
+
+pub enum DetailedGifError {
+  InvalidSignature(String)
+  UnsupportedVersion(String)
+  InvalidBlockSize(Int)
+  InvalidLzwMinimumCodeSize(Int)
+  InvalidColorTableSize(Int)
+  ImageTooLarge(Int, Int)
+  InvalidDisposalMethod(Int)
+  CorruptedSubBlock
+}
+pub impl Show for DetailedGifError
+
+pub enum DisposalMethod {
+  None
+  DoNotDispose
+  RestoreToBackground
+  RestoreToPrevious
+}
+pub impl Eq for DisposalMethod
+pub impl Show for DisposalMethod
+
+pub enum ExtensionType {
+  PlainText(PlainTextExtension)
+  GraphicControl(GraphicControlExtension)
+  Comment(CommentExtension)
+  Application(ApplicationExtension)
+}
+pub impl Show for ExtensionType
+
+pub struct Gif {
+  header : GifHeader
+  logical_screen : LogicalScreenDescriptor
+  global_color_table : @list.List[ColorTableEntry]?
+  data_blocks : @list.List[GifDataBlock]
+}
+pub impl Show for Gif
+
+pub enum GifDataBlock {
+  Extension(ExtensionType)
+  Image(ImageData)
+  Trailer
+}
+pub impl Show for GifDataBlock
+
+pub struct GifEncoder {
+  options : GifEncoderOptions
+  frames : Array[GifFrameInput]
+}
+pub fn GifEncoder::add_frame(Self, GifFrameInput) -> Result[Unit, GifError]
+pub fn GifEncoder::build(Self) -> Result[Bytes, GifError]
+pub fn GifEncoder::frame_count(Self) -> Int
+pub fn GifEncoder::new(GifEncoderOptions) -> Self
+pub impl Show for GifEncoder
+
+pub struct GifEncoderOptions {
+  width : Int
+  height : Int
+  global_color_table : @list.List[ColorTableEntry]?
+  background_color_index : Int
+  pixel_aspect_ratio : Int
+  loop_count : Int
+}
+pub impl Show for GifEncoderOptions
+
+pub enum GifError {
+  InvalidHeader
+  InvalidLogicalScreen
+  InvalidColorTable
+  InvalidImageDescriptor
+  InvalidExtension
+  InvalidFormat
+  LzwDecodingError
+  NoColorTable
+  UnsupportedFeature
+  DataCorrupted
+  UnexpectedEndOfFile
+  InvalidBlockSize(Int)
+}
+pub impl Show for GifError
+
+pub struct GifFrameInput {
+  descriptor : ImageDescriptor
+  color_indexes : @list.List[Byte]
+  local_color_table : @list.List[ColorTableEntry]?
+  delay_time : Int
+  disposal_method : Int
+  transparent_index : Int?
+}
+pub impl Show for GifFrameInput
+
+pub struct GifHeader {
+  signature : String
+  version : String
+}
+pub impl Show for GifHeader
+
+pub struct GifInfo {
+  version : String
+  width : Int
+  height : Int
+  has_global_color_table : Bool
+  global_color_table_size : Int
+  color_resolution : Int
+  sort_flag : Bool
+  bg_color_index : Int
+  pixel_aspect_ratio : Int
+}
+pub impl Show for GifInfo
+
+pub struct GifOptimizationOptions {
+  remove_duplicate_frames : Bool
+  enforce_transparent_background : Bool
+  prefer_global_palette : Bool
+  shrink_local_palettes : Bool
+}
+pub impl Show for GifOptimizationOptions
+
+pub struct GifParseOptions {
+  decompress_image_data : Bool
+  strict_mode : Bool
+  max_pixels : Int?
+}
+pub impl Show for GifParseOptions
+
+pub struct GraphicControlExtension {
+  disposal_method : Int
+  user_input_flag : Bool
+  transparent_color_flag : Bool
+  delay_time : Int
+  transparent_color_index : Int
+}
+pub impl Show for GraphicControlExtension
+
+pub struct ImageData {
+  descriptor : ImageDescriptor
+  local_color_table : @list.List[ColorTableEntry]?
+  image_data : @list.List[Byte]
+}
+pub impl Show for ImageData
+
+pub struct ImageDesc {
+  left : Int
+  top : Int
+  width : Int
+  height : Int
+  has_local_color_table : Bool
+  interlaced : Bool
+  sorted : Bool
+  local_color_table_size : Int
+}
+pub impl Show for ImageDesc
+
+pub struct ImageDescriptor {
+  left : Int
+  top : Int
+  width : Int
+  height : Int
+  local_color_table_flag : Bool
+  interlace_flag : Bool
+  sort_flag : Bool
+  local_color_table_size : Int
+}
+pub impl Show for ImageDescriptor
+
+pub struct ImageFrame {
+  width : Int
+  height : Int
+  pixels : Array[RgbaColor]
+  delay : Int
+  disposal_method : Int
+  transparent_index : Int?
+}
+pub impl Show for ImageFrame
+
+pub struct LogicalScreenDescriptor {
+  screen_width : Int
+  screen_height : Int
+  global_color_table_flag : Bool
+  color_resolution : Int
+  sort_flag : Bool
+  global_color_table_size : Int
+  background_color_index : Int
+  pixel_aspect_ratio : Int
+}
+pub impl Show for LogicalScreenDescriptor
+
+pub struct LzwDecoder {
+  dictionary : Array[LzwEntry]
+  mut code_size : Int
+  mut clear_code : Int
+  mut end_code : Int
+  mut next_code : Int
+  mut max_code : Int
+  mut dictionary_size : Int
+}
+pub fn LzwDecoder::add_to_dictionary(Self, Int, Byte) -> Unit
+pub fn LzwDecoder::get_first_char(Self, Int) -> Byte
+pub fn LzwDecoder::get_string(Self, Int) -> @list.List[Byte]
+pub fn LzwDecoder::new(Int) -> Self
+pub fn LzwDecoder::reset_dictionary(Self, Int) -> Unit
+
+pub struct LzwEntry {
+  prefix : Int
+  suffix : Byte
+}
+
+pub struct OptimizationReport {
+  removed_frames : Int
+  updated_transparency : Int
+  normalized_palettes : Int
+}
+pub impl Show for OptimizationReport
+
+pub struct PlainTextExtension {
+  text_grid_left_position : Int
+  text_grid_top_position : Int
+  text_grid_width : Int
+  text_grid_height : Int
+  character_cell_width : Int
+  character_cell_height : Int
+  text_foreground_color_index : Int
+  text_background_color_index : Int
+  plain_text_data : @list.List[Byte]
+}
+pub impl Show for PlainTextExtension
+
+pub struct RgbaColor {
+  red : Int
+  green : Int
+  blue : Int
+  alpha : Int
+}
+pub impl Eq for RgbaColor
+pub impl Show for RgbaColor
+
+pub struct StreamingDecoderOptions {
+  decompress_image_data : Bool
+  strict_mode : Bool
+  compact_threshold : Int
+}
+pub impl Show for StreamingDecoderOptions
+
+pub enum StreamingEvent {
+  Header(GifHeader, LogicalScreenDescriptor)
+  GlobalColorTable(@list.List[ColorTableEntry])
+  GraphicControl(GraphicControlExtension)
+  Comment(CommentExtension)
+  PlainText(PlainTextExtension)
+  Application(ApplicationExtension)
+  Image(ImageData, GraphicControlExtension?)
+  Trailer
+}
+pub impl Show for StreamingEvent
+
+pub struct StreamingGifDecoder {
+  options : StreamingDecoderOptions
+  mut buffer : Array[Byte]
+  mut consumed : Int
+  mut finished : Bool
+  mut header : GifHeader?
+  mut logical_screen : LogicalScreenDescriptor?
+  mut global_table_emitted : Bool
+  mut pending_graphic_control : GraphicControlExtension?
+}
+pub fn StreamingGifDecoder::finish(Self) -> Result[Unit, GifError]
+pub fn StreamingGifDecoder::is_finished(Self) -> Bool
+pub fn StreamingGifDecoder::new(StreamingDecoderOptions) -> Self
+pub fn StreamingGifDecoder::process_chunk(Self, Bytes) -> Result[@list.List[StreamingEvent], GifError]
+pub impl Show for StreamingGifDecoder
+
+pub struct TransparencyOptions {
+  strategy : TransparencyStrategy
+  alpha_threshold : Int
+  preserve_background : Bool
+  fallback_color : RgbaColor
+}
+pub impl Show for TransparencyOptions
+
+pub enum TransparencyStrategy {
+  Binary
+  AlphaThreshold
+  PreserveAlpha
+}
+pub impl Eq for TransparencyStrategy
+pub impl Show for TransparencyStrategy
+
+// Type aliases
+
+// Traits
+

--- a/src/main/pkg.generated.mbti
+++ b/src/main/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "Penguinsltp/gif_decoder/src/main"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/tests/gif_decoder_tests.mbt
+++ b/src/tests/gif_decoder_tests.mbt
@@ -548,7 +548,9 @@ test "测试通过解析获得的图像描述符功能" {
       inspect(desc.local_color_table_size, content="16")
 
       // 测试创建ImageData
-      let test_pixel_data = @list.from_array([b'P', b'I', b'X', b'E', b'L', b'S'])
+      let test_pixel_data = @list.from_array([
+        b'P', b'I', b'X', b'E', b'L', b'S',
+      ])
       let image_data = @gif_decoder_lib.create_image_data(desc, test_pixel_data)
       inspect(image_data.descriptor.width, content="200")
       inspect(image_data.descriptor.height, content="150")

--- a/src/tests/gif_encoder_tests.mbt
+++ b/src/tests/gif_encoder_tests.mbt
@@ -93,11 +93,11 @@ test "advanced transparency handles brightness threshold" {
     true,
     @gif_decoder_lib.create_rgba_color(0, 0, 0, 0),
   )
-  let color_table = @list.of([
+  let color_table = @list.List::from_array([
     @gif_decoder_lib.create_color_entry(10, 10, 10),
     @gif_decoder_lib.create_color_entry(240, 240, 240),
   ])
-  let indices = @list.of([b'\x00', b'\x01'])
+  let indices = @list.List::from_array([b'\x00', b'\x01'])
   let converted = @gif_decoder_lib.apply_color_table_with_options(
     indices,
     color_table,

--- a/src/tests/pkg.generated.mbti
+++ b/src/tests/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "Penguinsltp/gif_decoder/src/tests"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
Replace deprecated @list.of with @list.List::from_array to eliminate warnings.